### PR TITLE
Added the 'decamelize' option in order to toggle it off if needed.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = (string, options) => {
 	options = Object.assign({
 		separator: '-',
 		customReplacements: [],
-		decamelize: true,
+		decamelize: true
 	}, options);
 
 	const separator = escapeStringRegexp(options.separator);

--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ module.exports = (string, options) => {
 
 	options = Object.assign({
 		separator: '-',
-		customReplacements: []
+		customReplacements: [],
+		decamelize: true,
 	}, options);
 
 	const separator = escapeStringRegexp(options.separator);
@@ -45,7 +46,9 @@ module.exports = (string, options) => {
 	]);
 
 	string = deburr(string);
-	string = decamelize(string);
+	if (options.decamelize) {
+		string = decamelize(string);
+	}
 	string = doCustomReplacements(string, customReplacements);
 	string = string.toLowerCase();
 	string = string.replace(/[^a-z\d]+/g, separator);


### PR DESCRIPTION
The decamelize method should be an option.
So that a string like "PaRiS" wouldn't be converted to "pa-ri-s".