### PR TITLE
Fix `customReplacements` option on empty string replacements

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const escapeStringRegexp = require('escape-string-regexp');
 
 const decamelize = string => {
 	return string
-		.replace(/([a-z\d])([A-Z])/g, `$1 $2`)
-		.replace(/([A-Z]+)([A-Z][a-z\d]+)/g, `$1 $2`);
+		.replace(/([a-z\d])([A-Z])/g, '$1 $2')
+		.replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1 $2');
 };
 
 const builtinReplacements = new Map([
@@ -16,7 +16,7 @@ const builtinReplacements = new Map([
 
 const doCustomReplacements = (string, replacements) => {
 	for (const [key, value] of replacements) {
-		string = string.replace(new RegExp(escapeStringRegexp(key), 'g'), ` ${value} `);
+		string = string.replace(new RegExp(escapeStringRegexp(key), 'g'), value.length > 0 ? ` ${value} ` : value);
 	}
 
 	return string;

--- a/test.js
+++ b/test.js
@@ -51,4 +51,10 @@ test('custom replacements', t => {
 			['🦄', 'licorne']
 		]
 	}), 'i-amour-licorne');
+
+	t.is(slugify('x.y.z', {
+		customReplacements: [
+			['.', '']
+		]
+	}), 'xyz');
 });


### PR DESCRIPTION
For some reason, `xo` was giving me this error `Strings must use singlequote.` when the second parameter of `replace` function was a template literal string on line 7 and 8. 

I tried with various version of `node` and `xo`. The problem persisted. Hence, I made the parameters normal strings. 

Fixes #9