### PR TITLE
Add option to not replace custom unicode range [resolves #8]

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ const slugify = (string, options) => {
 		lowercase: true,
 		decamelize: true,
 		customReplacements: [],
+		unicodeRange: false,
 		...options
 	};
 
@@ -52,11 +53,17 @@ const slugify = (string, options) => {
 		string = decamelize(string);
 	}
 
-	let patternSlug = /[^a-zA-Z\d]+/g;
+	let patternSlug =
+		options.unicodeRange ?
+			new RegExp(`[^a-zA-Z\\d${options.unicodeRange}]+`, 'g') :
+			/[^a-zA-Z\d]+/g;
 
 	if (options.lowercase) {
 		string = string.toLowerCase();
-		patternSlug = /[^a-z\d]+/g;
+		patternSlug =
+			options.unicodeRange ?
+				new RegExp(`[^a-z\\d${options.unicodeRange}]+`, 'g') :
+				/[^a-z\d]+/g;
 	}
 
 	string = string.replace(patternSlug, separator);

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,20 @@ slugify('foo@unicorn', {
 //=> 'foo-at-unicorn'
 ```
 
+##### Custom Unicode Range
+
+Pass a [Unicode Charachter Range](https://jrgraphix.net/research/unicode_blocks.php) as an option to keep it from being replaced.
+
+```js
+const slugify = require('@sindresorhus/slugify');
+
+// CJK Unified Ideographs
+slugify('爱就是答案', {
+	unicodeRange: '\u4E00-\u9FFF'
+});
+//=> '爱就是答案'
+```
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -82,6 +82,14 @@ test('decamelize option', t => {
 	t.is(slugify('fooBar', {decamelize: false}), 'foobar');
 });
 
+test('unicode range option', t => {
+	t.is(slugify('爱就是答案', {
+		unicodeRange: '\u4E00-\u9FFF'
+	}), '爱就是答案', 'CJK Unified Ideographs');
+	t.is(slugify('प्यार', {unicodeRange: '\u0900-\u097F'}), 'प्यार', 'Devanagari');
+	t.is(slugify('love, and, peace, and happiness', {unicodeRange: '\u4E00-\u9FFF'}), 'love-and-peace-and-happiness');
+});
+
 test('supports German umlauts', t => {
 	t.is(slugify('ä ö ü Ä Ö Ü ß', {lowercase: false, separator: ' '}), 'ae oe ue Ae Oe Ue ss');
 });

--- a/test.js
+++ b/test.js
@@ -83,9 +83,7 @@ test('decamelize option', t => {
 });
 
 test('unicode range option', t => {
-	t.is(slugify('爱就是答案', {
-		unicodeRange: '\u4E00-\u9FFF'
-	}), '爱就是答案', 'CJK Unified Ideographs');
+	t.is(slugify('爱就是答案', {unicodeRange: '\u4E00-\u9FFF'}), '爱就是答案', 'CJK Unified Ideographs');
 	t.is(slugify('प्यार', {unicodeRange: '\u0900-\u097F'}), 'प्यार', 'Devanagari');
 	t.is(slugify('love, and, peace, and happiness', {unicodeRange: '\u4E00-\u9FFF'}), 'love-and-peace-and-happiness');
 });


### PR DESCRIPTION
I added an option to pass a unicode range, as proposed in fixes https://github.com/sindresorhus/slugify/issues/8. If a user does so, the pattern range is created from a string literal containing the range.

The creation of `patternSlug` seemed like the logical point to do it.

Maybe this should be in a function rather than a ternary?

I added tests for CJK and Devanagari as well as a test for a latin string, to make sure there are no regressions. 

Looking forward to your feedback.