### PR TITLE
Separate capitalized words

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const builtinOverridableReplacements = require('./overridable-replacements');
 
 const decamelize = string => {
 	return string
+		.replace(/([A-Z]{2,})([a-z\d]+)/g, '$1 $2')
+		.replace(/([a-z\d]+)([A-Z]{2,})/g, '$1 $2')
 		.replace(/([a-z\d])([A-Z])/g, '$1 $2')
 		.replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1 $2');
 };

--- a/index.js
+++ b/index.js
@@ -6,8 +6,10 @@ const builtinOverridableReplacements = require('./overridable-replacements');
 
 const decamelize = string => {
 	return string
+		// Separate capitalized words.
 		.replace(/([A-Z]{2,})([a-z\d]+)/g, '$1 $2')
 		.replace(/([a-z\d]+)([A-Z]{2,})/g, '$1 $2')
+
 		.replace(/([a-z\d])([A-Z])/g, '$1 $2')
 		.replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1 $2');
 };

--- a/test.js
+++ b/test.js
@@ -21,6 +21,9 @@ test('main', t => {
 	t.is(slugify('foo🦄'), 'foo-unicorn');
 	t.is(slugify('🦄🦄🦄'), 'unicorn-unicorn-unicorn');
 	t.is(slugify('foo&bar'), 'foo-and-bar');
+	t.is(slugify('foo360BAR'), 'foo360-bar');
+	t.is(slugify('FOO360'), 'foo-360');
+	t.is(slugify('FOObar'), 'foo-bar');
 });
 
 test('custom separator', t => {


### PR DESCRIPTION
Separates capitalized words (`FOObar` ~> `foo-bar`).
Regex101 Test: https://regex101.com/r/IraTqG/1

Fixes #31
Fixes #35