### PR TITLE
Add leading underscore option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ declare namespace slugify {
 		readonly customReplacements?: ReadonlyArray<[string, string]>;
 
 		/**
-		It preserves leading underscore.
+		If your string starts with an underscore, it will be preserved in the slugified string.
 
 		@default false
 
@@ -95,6 +95,9 @@ declare namespace slugify {
 
 		slugify('_foo_bar', {preserveLeadingUnderscore: true});
 		//=> '_foo-bar'
+
+		slugify('_hidden_filename', {preserveLeadingUnderscore: true});
+		//=> '_hidden-filename'
 		```
 		*/
 		readonly preserveLeadingUnderscore?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,6 +80,24 @@ declare namespace slugify {
 		```
 		*/
 		readonly customReplacements?: ReadonlyArray<[string, string]>;
+
+		/**
+		It preserves leading underscore.
+
+		@default false
+
+		@example
+		```
+		import slugify = require('@sindresorhus/slugify');
+
+		slugify('_foo_bar');
+		//=> 'foo-bar'
+
+		slugify('_foo_bar', {preserveLeadingUnderscore: true});
+		//=> '_foo-bar'
+		```
+		*/
+		readonly preserveLeadingUnderscore?: boolean;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,9 +96,6 @@ declare namespace slugify {
 
 		slugify('_foo_bar', {preserveLeadingUnderscore: true});
 		//=> '_foo-bar'
-
-		slugify('_hidden_filename', {preserveLeadingUnderscore: true});
-		//=> '_hidden-filename'
 		```
 		*/
 		readonly preserveLeadingUnderscore?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,8 @@ declare namespace slugify {
 		readonly customReplacements?: ReadonlyArray<[string, string]>;
 
 		/**
-		If your string starts with an underscore, it will be preserved in the slugified string.
+		If your string starts with an underscore, it will be preserved in the slugified string. 
+		Sometimes leading underscores are intentional, for example, filenames representing hidden paths on a website.
 
 		@default false
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ const slugify = (string, options) => {
 		...options
 	};
 
+	const shouldPrependUnderscore = options.preserveLeadingUnderscore && string.startsWith('_');
+
 	const separator = escapeStringRegexp(options.separator);
 
 	const customReplacements = new Map([
@@ -65,7 +67,6 @@ const slugify = (string, options) => {
 		patternSlug = /[^a-z\d]+/g;
 	}
 
-	const shouldPrependUnderscore = options.preserveLeadingUnderscore && string.startsWith('_');
 	string = string.replace(patternSlug, separator);
 	string = string.replace(/\\/g, '');
 	string = removeMootSeparators(string, separator);

--- a/index.js
+++ b/index.js
@@ -35,10 +35,10 @@ const slugify = (string, options) => {
 
 	options = {
 		separator: '-',
-		leadingUnderscore: false,
 		lowercase: true,
 		decamelize: true,
 		customReplacements: [],
+		preserveLeadingUnderscore: false,
 		...options
 	};
 
@@ -65,7 +65,7 @@ const slugify = (string, options) => {
 		patternSlug = /[^a-z\d]+/g;
 	}
 
-	if (options.leadingUnderscore) {
+	if (options.preserveLeadingUnderscore) {
 		let patternSlugString = patternSlug.source;
 		patternSlugString = `(?!^)_?${patternSlugString}`;
 		patternSlug = new RegExp(patternSlugString, 'g');

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ const slugify = (string, options) => {
 
 	options = {
 		separator: '-',
+		leadingUnderscore: false,
 		lowercase: true,
 		decamelize: true,
 		customReplacements: [],
@@ -62,6 +63,12 @@ const slugify = (string, options) => {
 	if (options.lowercase) {
 		string = string.toLowerCase();
 		patternSlug = /[^a-z\d]+/g;
+	}
+
+	if (options.leadingUnderscore) {
+		let patternSlugString = patternSlug.source;
+		patternSlugString = `(?!^)_?${patternSlugString}`;
+		patternSlug = new RegExp(patternSlugString, 'g');
 	}
 
 	string = string.replace(patternSlug, separator);

--- a/index.js
+++ b/index.js
@@ -65,15 +65,13 @@ const slugify = (string, options) => {
 		patternSlug = /[^a-z\d]+/g;
 	}
 
-	if (options.preserveLeadingUnderscore) {
-		let patternSlugString = patternSlug.source;
-		patternSlugString = `(?!^)_?${patternSlugString}`;
-		patternSlug = new RegExp(patternSlugString, 'g');
-	}
-
+	const shouldPrependUnderscore = options.preserveLeadingUnderscore && string.startsWith('_');
 	string = string.replace(patternSlug, separator);
 	string = string.replace(/\\/g, '');
 	string = removeMootSeparators(string, separator);
+	if (shouldPrependUnderscore) {
+		string = '_' + string;
+	}
 
 	return string;
 };

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ const slugify = (string, options) => {
 	string = string.replace(/\\/g, '');
 	string = removeMootSeparators(string, separator);
 	if (shouldPrependUnderscore) {
-		string = '_' + string;
+		string = `_${string}`;
 	}
 
 	return string;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,3 +8,4 @@ expectType<string>(slugify('fooBar', {decamelize: false}));
 expectType<string>(
 	slugify('I ♥ 🦄 & 🐶', {customReplacements: [['🐶', 'dog']]})
 );
+expectType<string>(slugify('_foo_bar', {preserveLeadingUnderscore: true}));

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,9 @@ slugify('_foo_bar');
 
 slugify('_foo_bar', {preserveLeadingUnderscore: true});
 //=> '_foo-bar'
+
+slugify('_hidden_filename', {preserveLeadingUnderscore: true});
+//=> '_hidden-filename'
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,7 @@ slugify('foo@unicorn', {
 Type: `boolean`\
 Default: `false`
 
-If your string starts with an underscore, it will be preserved in the slugified string.
+If your string starts with an underscore, it will be preserved in the slugified string. Sometimes leading underscores are intentional, for example, filenames representing hidden paths on a website.
 
 ```js
 const slugify = require('@sindresorhus/slugify');

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,23 @@ slugify('foo@unicorn', {
 //=> 'foo-at-unicorn'
 ```
 
+##### customReplacements
+
+Type: `boolean`\
+Default: `false`
+
+Allow leading underscore as an escape `_foo_bar` → `_foo-bar`.
+
+```js
+const slugify = require('@sindresorhus/slugify');
+
+slugify('_foo_bar');
+//=> 'foo-bar'
+
+slugify('_foo_bar', {leadingUnderscore: true});
+//=> '_foo-bar'
+```
+
 ## Related
 
 - [slugify-cli](https://github.com/sindresorhus/slugify-cli) - CLI for this module

--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,9 @@ slugify('foo@unicorn', {
 Type: `boolean`\
 Default: `false`
 
-If your string starts with an underscore, it will be preserved in the slugified string. Sometimes leading underscores are intentional, for example, filenames representing hidden paths on a website.
+If your string starts with an underscore, it will be preserved in the slugified string.
+
+Sometimes leading underscores are intentional, for example, filenames representing hidden paths on a website.
 
 ```js
 const slugify = require('@sindresorhus/slugify');
@@ -147,9 +149,6 @@ slugify('_foo_bar');
 
 slugify('_foo_bar', {preserveLeadingUnderscore: true});
 //=> '_foo-bar'
-
-slugify('_hidden_filename', {preserveLeadingUnderscore: true});
-//=> '_hidden-filename'
 ```
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -132,12 +132,12 @@ slugify('foo@unicorn', {
 //=> 'foo-at-unicorn'
 ```
 
-##### customReplacements
+##### preserveLeadingUnderscore
 
 Type: `boolean`\
 Default: `false`
 
-Allow leading underscore as an escape `_foo_bar` → `_foo-bar`.
+It preserves leading underscore: `_foo_bar` → `_foo-bar`.
 
 ```js
 const slugify = require('@sindresorhus/slugify');
@@ -145,7 +145,7 @@ const slugify = require('@sindresorhus/slugify');
 slugify('_foo_bar');
 //=> 'foo-bar'
 
-slugify('_foo_bar', {leadingUnderscore: true});
+slugify('_foo_bar', {preserveLeadingUnderscore: true});
 //=> '_foo-bar'
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,7 @@ slugify('foo@unicorn', {
 Type: `boolean`\
 Default: `false`
 
-It preserves leading underscore: `_foo_bar` → `_foo-bar`.
+If your string starts with an underscore, it will be preserved in the slugified string.
 
 ```js
 const slugify = require('@sindresorhus/slugify');

--- a/test.js
+++ b/test.js
@@ -124,3 +124,8 @@ test('supports Turkish', t => {
 test('supports Armenian', t => {
 	t.is(slugify('Ե ր ե ւ ա ն', {lowercase: false, separator: ' '}), 're ye v a n');
 });
+
+test('leading underscore', t => {
+	t.is(slugify('_foo bar', {leadingUnderscore: true}), '_foo-bar');
+	t.is(slugify('_foo_bar', {leadingUnderscore: true}), '_foo-bar');
+});

--- a/test.js
+++ b/test.js
@@ -126,6 +126,7 @@ test('supports Armenian', t => {
 });
 
 test('leading underscore', t => {
-	t.is(slugify('_foo bar', {leadingUnderscore: true}), '_foo-bar');
-	t.is(slugify('_foo_bar', {leadingUnderscore: true}), '_foo-bar');
+	t.is(slugify('_foo bar', {preserveLeadingUnderscore: true}), '_foo-bar');
+	t.is(slugify('_foo_bar', {preserveLeadingUnderscore: true}), '_foo-bar');
+	t.is(slugify('__foo__bar', {preserveLeadingUnderscore: true}), '_-foo-bar');
 });

--- a/test.js
+++ b/test.js
@@ -128,5 +128,6 @@ test('supports Armenian', t => {
 test('leading underscore', t => {
 	t.is(slugify('_foo bar', {preserveLeadingUnderscore: true}), '_foo-bar');
 	t.is(slugify('_foo_bar', {preserveLeadingUnderscore: true}), '_foo-bar');
-	t.is(slugify('__foo__bar', {preserveLeadingUnderscore: true}), '_-foo-bar');
+	t.is(slugify('__foo__bar', {preserveLeadingUnderscore: true}), '_foo-bar');
+	t.is(slugify('____-___foo__bar', {preserveLeadingUnderscore: true}), '_foo-bar');
 });


### PR DESCRIPTION
[Fixes #39]
I created a new leading underscore parameter for the function as false at default. But, when it's true, it changes the current regexp to accept the leading underscore:

Example:
```js
slugify("_foo bar", { leadingUnderscore: true })

Output: _foo-bar
```
 