### PR TITLE
Add counter for multiple occurences

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -161,4 +161,3 @@ declare const slugify: {
 }
 
 export = slugify;
-

--- a/index.d.ts
+++ b/index.d.ts
@@ -163,7 +163,7 @@ declare const slugify: {
 	//=> 'foo-bar'
 	```
 
-	Use case example of counter
+	__Use case example of counter__
 
 	If, for example, you have a document with multiple sections where each subsection has an example.
 
@@ -175,7 +175,6 @@ declare const slugify: {
 	## Section 2
 
 	### Example
-
 	```
 
 	You can then use `slugify.counter()` to generate unique HTML `id`'s to ensure anchors will link to the right headline.

--- a/index.d.ts
+++ b/index.d.ts
@@ -142,7 +142,7 @@ declare const slugify: {
 	): string;
 
 	/**
-	Creates a counter to ensure uniqueness.
+	Returns a new instance of `slugify(string, options?)` with a counter to handle multiple occurences of the same string.
 
 	@param string - String to slugify.
 
@@ -162,6 +162,23 @@ declare const slugify: {
 	countableSlugify('foo bar');
 	//=> 'foo-bar'
 	```
+
+	Use case example of counter
+
+	If, for example, you have a document with multiple sections where each subsection has an example.
+
+	```
+	## Section 1
+
+	### Example
+
+	## Section 2
+
+	### Example
+
+	```
+
+	You can then use `slugify.counter()` to generate unique HTML `id`'s to ensure anchors will link to the right headline.
 	*/
 	counter: () => {
 		(

--- a/index.d.ts
+++ b/index.d.ts
@@ -167,11 +167,28 @@ declare const slugify: {
 		(
 			string: string,
 			options?: slugify.Options
-		): string;
+			): string;
 
 		/**
-		 * Reset the counter
-		 */
+		Reset the counter
+
+		@example
+		```
+		import slugify = require('@sindresorhus/slugify');
+
+		const countableSlugify = slugify.counter();
+		countableSlugify('foo bar');
+		//=> 'foo-bar'
+
+		countableSlugify('foo bar');
+		//=> 'foo-bar-2'
+
+		countableSlugify.reset();
+
+		countableSlugify('foo bar');
+		//=> 'foo-bar'
+		```
+		*/
 		reset(): void;
 	};
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -133,6 +133,15 @@ slugify('fooBar 123 $#%');
 
 slugify('я люблю единорогов');
 //=> 'ya-lyublyu-edinorogov'
+
+const countableSlugify = slugify.counter();
+countableSlugify('Be a unicorn');
+// => 'be-a-unicorn'
+countableSlugify('Be a unicorn');
+// => 'be-a-unicorn-2'
+countableSlugify.reset();
+countableSlugify('Be a unicorn');
+// => 'be-a-unicorn'
 ```
 */
 declare const slugify: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -133,29 +133,45 @@ slugify('fooBar 123 $#%');
 
 slugify('я люблю единорогов');
 //=> 'ya-lyublyu-edinorogov'
-
-const countableSlugify = slugify.counter();
-countableSlugify('Be a unicorn');
-// => 'be-a-unicorn'
-countableSlugify('Be a unicorn');
-// => 'be-a-unicorn-2'
-countableSlugify.reset();
-countableSlugify('Be a unicorn');
-// => 'be-a-unicorn'
 ```
 */
 declare const slugify: {
 	(
 		string: string,
 		options?: slugify.Options
-	): string;
+		): string;
 
+	/**
+	Adds a counter to ensure uniquenes.
+
+	@param string - String to slugify.
+
+	@example
+	```
+	import slugify = require('@sindresorhus/slugify');
+
+	const countableSlugify = slugify.counter();
+	countableSlugify('foo bar');
+	//=> 'foo-bar'
+
+	countableSlugify('foo bar');
+	//=> 'foo-bar-2'
+
+	countableSlugify.reset();
+
+	countableSlugify('foo bar');
+	//=> 'foo-bar'
+	```
+	*/
 	counter: () => {
 		(
 			string: string,
 			options?: slugify.Options
 		): string;
 
+		/**
+		 * Reset the counter
+		 */
 		reset(): void;
 	};
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -135,16 +135,21 @@ slugify('я люблю единорогов');
 //=> 'ya-lyublyu-edinorogov'
 ```
 */
-declare function slugify(
-	string: string,
-	options?: slugify.Options
-): string;
+declare const slugify: {
+	(
+		string: string,
+		options?: slugify.Options
+	): string;
+
+	counter: () => {
+		(
+			string: string,
+			options?: slugify.Options
+		): string;
+
+		reset(): void;
+	};
+}
 
 export = slugify;
 
-declare function counter(
-	string: string,
-	options?: slugify.Options
-): string;
-
-declare function reset(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -113,36 +113,36 @@ declare namespace slugify {
 	}
 }
 
-/**
-Slugify a string.
-
-@param string - String to slugify.
-
-@example
-```
-import slugify = require('@sindresorhus/slugify');
-
-slugify('I ♥ Dogs');
-//=> 'i-love-dogs'
-
-slugify('  Déjà Vu!  ');
-//=> 'deja-vu'
-
-slugify('fooBar 123 $#%');
-//=> 'foo-bar-123'
-
-slugify('я люблю единорогов');
-//=> 'ya-lyublyu-edinorogov'
-```
-*/
 declare const slugify: {
+	/**
+	Slugify a string.
+
+	@param string - String to slugify.
+
+	@example
+	```
+	import slugify = require('@sindresorhus/slugify');
+
+	slugify('I ♥ Dogs');
+	//=> 'i-love-dogs'
+
+	slugify('  Déjà Vu!  ');
+	//=> 'deja-vu'
+
+	slugify('fooBar 123 $#%');
+	//=> 'foo-bar-123'
+
+	slugify('я люблю единорогов');
+	//=> 'ya-lyublyu-edinorogov'
+	```
+	*/
 	(
 		string: string,
 		options?: slugify.Options
-		): string;
+	): string;
 
 	/**
-	Adds a counter to ensure uniquenes.
+	Creates a counter to ensure uniqueness.
 
 	@param string - String to slugify.
 
@@ -167,10 +167,10 @@ declare const slugify: {
 		(
 			string: string,
 			options?: slugify.Options
-			): string;
+		): string;
 
 		/**
-		Reset the counter
+		Reset the counter.
 
 		@example
 		```

--- a/index.d.ts
+++ b/index.d.ts
@@ -141,3 +141,10 @@ declare function slugify(
 ): string;
 
 export = slugify;
+
+declare function counter(
+	string: string,
+	options?: slugify.Options
+): string;
+
+declare function reset(): void;

--- a/index.js
+++ b/index.js
@@ -71,7 +71,11 @@ const counter = () => {
 
 	const countable = (string, options) => {
 		string = slugify(string, options);
-		if (!string) return '';
+
+		if (!string) {
+			return '';
+		}
+
 		const stringLower = string.toLowerCase();
 		const numberless = occurrences.get(stringLower.replace(/(?:-\d+?)+?$/, '')) || 0;
 		const counter = occurrences.get(stringLower);

--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ module.exports.counter = () => {
 		if (newCounter >= 2 || numberless > 2) {
 			string = `${string}-${newCounter}`;
 		}
+
 		return string;
 	};
 };

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const removeMootSeparators = (string, separator) => {
 		.replace(new RegExp(`^${escapedSeparator}|${escapedSeparator}$`, 'g'), '');
 };
 
-module.exports = (string, options) => {
+const slugify = (string, options) => {
 	if (typeof string !== 'string') {
 		throw new TypeError(`Expected a string, got \`${typeof string}\``);
 	}
@@ -64,4 +64,27 @@ module.exports = (string, options) => {
 	}
 
 	return string;
+};
+
+module.exports = slugify;
+
+const occurrences = new Map();
+
+module.exports.counter = () => {
+	return (string, options) => {
+		string = slugify(string, options);
+		const stringLower = string.toLowerCase();
+		const numberless = occurrences.get(stringLower.replace(/(?:-\d+?)+?$/, '')) || 0;
+		const counter = occurrences.get(stringLower);
+		occurrences.set(stringLower, typeof counter === 'number' ? counter + 1 : 1);
+		const newCounter = occurrences.get(stringLower) || 2;
+		if (newCounter >= 2 || numberless > 2) {
+			string = `${string}-${newCounter}`;
+		}
+		return string;
+	};
+};
+
+module.exports.reset = () => {
+	occurrences.clear();
 };

--- a/index.js
+++ b/index.js
@@ -66,12 +66,10 @@ const slugify = (string, options) => {
 	return string;
 };
 
-module.exports = slugify;
+const counter = () => {
+	const occurrences = new Map();
 
-const occurrences = new Map();
-
-module.exports.counter = () => {
-	return (string, options) => {
+	const countable = (string, options) => {
 		string = slugify(string, options);
 		const stringLower = string.toLowerCase();
 		const numberless = occurrences.get(stringLower.replace(/(?:-\d+?)+?$/, '')) || 0;
@@ -84,8 +82,13 @@ module.exports.counter = () => {
 
 		return string;
 	};
+
+	countable.reset = () => {
+		occurrences.clear();
+	};
+
+	return countable;
 };
 
-module.exports.reset = () => {
-	occurrences.clear();
-};
+module.exports = slugify;
+module.exports.counter = counter;

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ const counter = () => {
 
 	const countable = (string, options) => {
 		string = slugify(string, options);
+		if (!string) return '';
 		const stringLower = string.toLowerCase();
 		const numberless = occurrences.get(stringLower.replace(/(?:-\d+?)+?$/, '')) || 0;
 		const counter = occurrences.get(stringLower);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,10 +5,8 @@ expectType<string>(slugify('I ♥ Dogs'));
 expectType<string>(slugify('BAR and baz', {separator: '_'}));
 expectType<string>(slugify('Déjà Vu!', {lowercase: false}));
 expectType<string>(slugify('fooBar', {decamelize: false}));
-expectType<string>(
-	slugify('I ♥ 🦄 & 🐶', {customReplacements: [['🐶', 'dog']]})
-	);
-	expectType<string>(slugify('_foo_bar', {preserveLeadingUnderscore: true}));
+expectType<string>(slugify('I ♥ 🦄 & 🐶', {customReplacements: [['🐶', 'dog']]}));
+expectType<string>(slugify('_foo_bar', {preserveLeadingUnderscore: true}));
 
 // counter
 expectType<string>(slugify.counter()('I ♥ Dogs'));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,5 +7,9 @@ expectType<string>(slugify('Déjà Vu!', {lowercase: false}));
 expectType<string>(slugify('fooBar', {decamelize: false}));
 expectType<string>(
 	slugify('I ♥ 🦄 & 🐶', {customReplacements: [['🐶', 'dog']]})
-);
-expectType<string>(slugify('_foo_bar', {preserveLeadingUnderscore: true}));
+	);
+	expectType<string>(slugify('_foo_bar', {preserveLeadingUnderscore: true}));
+
+// counter
+expectType<string>(slugify.counter()('I ♥ Dogs'));
+expectType<void>(slugify.counter().reset());

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,45 @@ slugify('_foo_bar', {preserveLeadingUnderscore: true});
 //=> '_foo-bar'
 ```
 
+### slugify.counter()
+
+Returns a new instance of `slugify(string, options?)` with a counter to handle multiple occurences of the same string.
+
+#### Example
+
+```js
+const slugify = require('@sindresorhus/slugify');
+
+const countableSlugify = slugify.counter();
+
+countableSlugify('foo bar');
+//=> 'foo-bar'
+
+countableSlugify('foo bar');
+//=> 'foo-bar-2'
+
+countableSlugify.reset();
+
+countableSlugify('foo bar');
+//=> 'foo-bar'
+```
+
+#### Use case example of counter
+
+If, for example, you have a document with multiple sections where each subsection has an example.
+
+```md
+## Section 1
+
+### Example
+
+## Section 2
+
+### Example
+```
+
+You can then use `slugify.counter()` to generate unique HTML `id`'s to ensure anchors will link to the right headline.
+
 ## Related
 
 - [slugify-cli](https://github.com/sindresorhus/slugify-cli) - CLI for this module

--- a/readme.md
+++ b/readme.md
@@ -187,7 +187,7 @@ countableSlugify('foo bar');
 //=> 'foo-bar'
 ```
 
-#### Use case example of counter
+#### Use-case example of counter
 
 If, for example, you have a document with multiple sections where each subsection has an example.
 
@@ -210,9 +210,10 @@ Reset the counter
 #### Example
 
 ```js
-import slugify = require('@sindresorhus/slugify');
+const slugify = require('@sindresorhus/slugify');
 
 const countableSlugify = slugify.counter();
+
 countableSlugify('foo bar');
 //=> 'foo-bar'
 

--- a/readme.md
+++ b/readme.md
@@ -203,6 +203,28 @@ If, for example, you have a document with multiple sections where each subsectio
 
 You can then use `slugify.counter()` to generate unique HTML `id`'s to ensure anchors will link to the right headline.
 
+### slugify.reset()
+
+Reset the counter
+
+#### Example
+
+```js
+import slugify = require('@sindresorhus/slugify');
+
+const countableSlugify = slugify.counter();
+countableSlugify('foo bar');
+//=> 'foo-bar'
+
+countableSlugify('foo bar');
+//=> 'foo-bar-2'
+
+countableSlugify.reset();
+
+countableSlugify('foo bar');
+//=> 'foo-bar'
+```
+
 ## Related
 
 - [slugify-cli](https://github.com/sindresorhus/slugify-cli) - CLI for this module

--- a/test.js
+++ b/test.js
@@ -145,13 +145,13 @@ test('counter', t => {
 	t.is(countableSlugify('foo'), 'foo-3');
 	t.is(countableSlugify('foo'), 'foo-4');
 	t.is(countableSlugify('foo-1'), 'foo-1-4');
-	t.is(countableSlugify('foo-2'), 'foo-2-1'); // or foo-2-2 ??
+	t.is(countableSlugify('foo-2'), 'foo-2-1'); // Or foo-2-2 ??
 	t.is(countableSlugify('foo-2'), 'foo-2-2');
 	t.is(countableSlugify('foo-2-1'), 'foo-2-1-1');
 	t.is(countableSlugify('foo-2-1'), 'foo-2-1-2');
 	t.is(countableSlugify('foo-11'), 'foo-11-1');
 	t.is(countableSlugify('foo-111'), 'foo-111-1');
 	t.is(countableSlugify('foo-111-1'), 'foo-111-1-1');
-	t.is(countableSlugify('fooCamelCase', { lowercase: false, decamelize: false }), 'fooCamelCase');
-	t.is(countableSlugify('fooCamelCase', { decamelize: false }), 'foocamelcase-2');
+	t.is(countableSlugify('fooCamelCase', {lowercase: false, decamelize: false}), 'fooCamelCase');
+	t.is(countableSlugify('fooCamelCase', {decamelize: false}), 'foocamelcase-2');
 });

--- a/test.js
+++ b/test.js
@@ -147,7 +147,7 @@ test('counter', t => {
 	t.is(countableSlugify('foo'), 'foo-3');
 	t.is(countableSlugify('foo'), 'foo-4');
 	t.is(countableSlugify('foo-1'), 'foo-1-4');
-	t.is(countableSlugify('foo-2'), 'foo-2-1'); // Or foo-2-2 ??
+	t.is(countableSlugify('foo-2'), 'foo-2-1');
 	t.is(countableSlugify('foo-2'), 'foo-2-2');
 	t.is(countableSlugify('foo-2-1'), 'foo-2-1-1');
 	t.is(countableSlugify('foo-2-1'), 'foo-2-1-2');

--- a/test.js
+++ b/test.js
@@ -163,4 +163,7 @@ test('counter', t => {
 	const countableSlugify2 = slugify.counter();
 	t.is(countableSlugify2('foo'), 'foo');
 	t.is(countableSlugify2('foo'), 'foo-2');
+
+	t.is(countableSlugify2(''), '');
+	t.is(countableSlugify2(''), '');
 });

--- a/test.js
+++ b/test.js
@@ -131,3 +131,27 @@ test('leading underscore', t => {
 	t.is(slugify('__foo__bar', {preserveLeadingUnderscore: true}), '_foo-bar');
 	t.is(slugify('____-___foo__bar', {preserveLeadingUnderscore: true}), '_foo-bar');
 });
+
+test('counter', t => {
+	const countableSlugify = slugify.counter();
+	t.is(countableSlugify('foo bar'), 'foo-bar');
+	t.is(countableSlugify('foo bar'), 'foo-bar-2');
+	slugify.reset();
+	t.is(countableSlugify('foo'), 'foo');
+	t.is(countableSlugify('foo'), 'foo-2');
+	t.is(countableSlugify('foo 1'), 'foo-1');
+	t.is(countableSlugify('foo-1'), 'foo-1-2');
+	t.is(countableSlugify('foo-1'), 'foo-1-3');
+	t.is(countableSlugify('foo'), 'foo-3');
+	t.is(countableSlugify('foo'), 'foo-4');
+	t.is(countableSlugify('foo-1'), 'foo-1-4');
+	t.is(countableSlugify('foo-2'), 'foo-2-1'); // or foo-2-2 ??
+	t.is(countableSlugify('foo-2'), 'foo-2-2');
+	t.is(countableSlugify('foo-2-1'), 'foo-2-1-1');
+	t.is(countableSlugify('foo-2-1'), 'foo-2-1-2');
+	t.is(countableSlugify('foo-11'), 'foo-11-1');
+	t.is(countableSlugify('foo-111'), 'foo-111-1');
+	t.is(countableSlugify('foo-111-1'), 'foo-111-1-1');
+	t.is(countableSlugify('fooCamelCase', { lowercase: false, decamelize: false }), 'fooCamelCase');
+	t.is(countableSlugify('fooCamelCase', { decamelize: false }), 'foocamelcase-2');
+});

--- a/test.js
+++ b/test.js
@@ -136,7 +136,9 @@ test('counter', t => {
 	const countableSlugify = slugify.counter();
 	t.is(countableSlugify('foo bar'), 'foo-bar');
 	t.is(countableSlugify('foo bar'), 'foo-bar-2');
+
 	countableSlugify.reset();
+
 	t.is(countableSlugify('foo'), 'foo');
 	t.is(countableSlugify('foo'), 'foo-2');
 	t.is(countableSlugify('foo 1'), 'foo-1');
@@ -154,6 +156,9 @@ test('counter', t => {
 	t.is(countableSlugify('foo-111-1'), 'foo-111-1-1');
 	t.is(countableSlugify('fooCamelCase', {lowercase: false, decamelize: false}), 'fooCamelCase');
 	t.is(countableSlugify('fooCamelCase', {decamelize: false}), 'foocamelcase-2');
+	t.is(countableSlugify('_foo'), 'foo-5');
+	t.is(countableSlugify('_foo', {preserveLeadingUnderscore: true}), '_foo');
+	t.is(countableSlugify('_foo', {preserveLeadingUnderscore: true}), '_foo-2');
 
 	const countableSlugify2 = slugify.counter();
 	t.is(countableSlugify2('foo'), 'foo');

--- a/test.js
+++ b/test.js
@@ -136,7 +136,7 @@ test('counter', t => {
 	const countableSlugify = slugify.counter();
 	t.is(countableSlugify('foo bar'), 'foo-bar');
 	t.is(countableSlugify('foo bar'), 'foo-bar-2');
-	slugify.reset();
+	countableSlugify.reset();
 	t.is(countableSlugify('foo'), 'foo');
 	t.is(countableSlugify('foo'), 'foo-2');
 	t.is(countableSlugify('foo 1'), 'foo-1');
@@ -154,4 +154,8 @@ test('counter', t => {
 	t.is(countableSlugify('foo-111-1'), 'foo-111-1-1');
 	t.is(countableSlugify('fooCamelCase', {lowercase: false, decamelize: false}), 'fooCamelCase');
 	t.is(countableSlugify('fooCamelCase', {decamelize: false}), 'foocamelcase-2');
+
+	const countableSlugify2 = slugify.counter();
+	t.is(countableSlugify2('foo'), 'foo');
+	t.is(countableSlugify2('foo'), 'foo-2');
 });


### PR DESCRIPTION
Closes https://github.com/sindresorhus/slugify/issues/37

That's actually what I already made for [@gaiama/slugger](https://github.com/GaiAma/Coding4GaiAma/tree/master/packages/gaiama-slugger)

only issue so far is, it's not doing the by you preferred `-2-2` 😢 

```js
t.is(countableSlugify('foo-2'), 'foo-2-1'); // or foo-2-2
```
and I'm currently not sure how to properly do it without a rewrite.
I'm open to other implementations or preferences.

`index.d.ts` is probably not correct? Still very new to TS and external declarations.

Also I'm not sure if the used regex `/(?:-\d+?)+?$/` is [ReDoS](https://en.wikipedia.org/wiki/ReDoS) safe or how much that matters here 🤷‍♂ 