### PR TITLE
Fix unsupported spread operation

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = (string, options) => {
 	const shouldPrependUnderscore = options.preserveLeadingUnderscore && string.startsWith('_');
 
 	const customReplacements = new Map(
-		[].concat(builtinOverridableReplacements).concat(options.customReplacements),
+		[].concat(builtinOverridableReplacements).concat(options.customReplacements).filter(Boolean),
 	);
 
 	string = transliterate(string, {customReplacements});

--- a/index.js
+++ b/index.js
@@ -26,21 +26,19 @@ module.exports = (string, options) => {
 		throw new TypeError(`Expected a string, got \`${typeof string}\``);
 	}
 
-	options = {
+	options = Object.assign({
 		separator: '-',
 		lowercase: true,
 		decamelize: true,
 		customReplacements: [],
 		preserveLeadingUnderscore: false,
-		...options
-	};
+	}, options);
 
 	const shouldPrependUnderscore = options.preserveLeadingUnderscore && string.startsWith('_');
 
-	const customReplacements = new Map([
-		...builtinOverridableReplacements,
-		...options.customReplacements
-	]);
+	const customReplacements = new Map(
+		[].concat(builtinOverridableReplacements).concat(options.customReplacements),
+	);
 
 	string = transliterate(string, {customReplacements});
 


### PR DESCRIPTION
Today object Rest/Spread Properties for ECMAScript is proposal. Without any compilation like babel it is break some browser (i.e. etc)
#47 issue about this