### PR TITLE
Add `preserveTrailingDash` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,7 +116,7 @@ export interface Options {
 	/**
 	If your string ends with a dash, it will be preserved in the slugified string.
 
-	Sometimes trailing dashes are intentional, for example, when using slugify on an input field used for setting a slug.
+	For example, using slugify on an input field would allow for validation while not preventing the user from writing a slug.
 
 	@default false
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,26 @@ export interface Options {
 	```
 	*/
 	readonly preserveLeadingUnderscore?: boolean;
+
+	/**
+	If your string ends with a dash, it will be preserved in the slugified string.
+
+	Sometimes trailing dashes are intentional, for example, when using slugify on an input field used for setting a slug.
+
+	@default false
+
+	@example
+	```
+	import slugify from '@sindresorhus/slugify';
+
+	slugify('foo-bar-');
+	//=> 'foo-bar'
+
+	slugify('foo-bar-', {preserveTrailingDash: true});
+	//=> 'foo-bar-'
+	```
+	 */
+	readonly preserveTrailingDash?: boolean;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -31,10 +31,12 @@ export default function slugify(string, options) {
 		decamelize: true,
 		customReplacements: [],
 		preserveLeadingUnderscore: false,
+		preserveTrailingDash: false,
 		...options
 	};
 
 	const shouldPrependUnderscore = options.preserveLeadingUnderscore && string.startsWith('_');
+	const shouldAppendDash = options.preserveTrailingDash && string.endsWith('-');
 
 	const customReplacements = new Map([
 		...builtinOverridableReplacements,
@@ -62,6 +64,10 @@ export default function slugify(string, options) {
 
 	if (shouldPrependUnderscore) {
 		string = `_${string}`;
+	}
+
+	if (shouldAppendDash) {
+		string = `${string}-`;
 	}
 
 	return string;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,6 +7,7 @@ expectType<string>(slugify('Déjà Vu!', {lowercase: false}));
 expectType<string>(slugify('fooBar', {decamelize: false}));
 expectType<string>(slugify('I ♥ 🦄 & 🐶', {customReplacements: [['🐶', 'dog']]}));
 expectType<string>(slugify('_foo_bar', {preserveLeadingUnderscore: true}));
+expectType<string>(slugify('foo-bar-', {preserveTrailingDash: true}));
 
 // Counter
 expectType<string>(slugifyWithCounter()('I ♥ Dogs'));

--- a/readme.md
+++ b/readme.md
@@ -174,7 +174,7 @@ Default: `false`
 
 If your string ends with a dash, it will be preserved in the slugified string.
 
-Sometimes trailing dashes are intentional, for example, when using slugify on an input field used for setting a slug.
+For example, using slugify on an input field would allow for validation while not preventing the user from writing a slug.
 
 ```js
 import slugify from '@sindresorhus/slugify';

--- a/readme.md
+++ b/readme.md
@@ -167,6 +167,25 @@ slugify('_foo_bar', {preserveLeadingUnderscore: true});
 //=> '_foo-bar'
 ```
 
+##### preserveTrailingDash
+
+Type: `boolean`\
+Default: `false`
+
+If your string ends with a dash, it will be preserved in the slugified string.
+
+Sometimes trailing dashes are intentional, for example, when using slugify on an input field used for setting a slug.
+
+```js
+import slugify from '@sindresorhus/slugify';
+
+slugify('foo-bar-');
+//=> 'foo-bar'
+
+slugify('foo-bar-', {preserveTrailingDash: true});
+//=> 'foo-bar-'
+```
+
 ### slugifyWithCounter()
 
 Returns a new instance of `slugify(string, options?)` with a counter to handle multiple occurences of the same string.

--- a/test.js
+++ b/test.js
@@ -133,6 +133,11 @@ test('leading underscore', t => {
 	t.is(slugify('____-___foo__bar', {preserveLeadingUnderscore: true}), '_foo-bar');
 });
 
+test('trailing dash', t => {
+	t.is(slugify('foo bar-', {preserveTrailingDash: true}), 'foo-bar-');
+	t.is(slugify('foo-bar--', {preserveTrailingDash: true}), 'foo-bar-');
+});
+
 test('counter', t => {
 	const slugify = slugifyWithCounter();
 	t.is(slugify('foo bar'), 'foo-bar');

--- a/test.js
+++ b/test.js
@@ -136,6 +136,9 @@ test('leading underscore', t => {
 test('trailing dash', t => {
 	t.is(slugify('foo bar-', {preserveTrailingDash: true}), 'foo-bar-');
 	t.is(slugify('foo-bar--', {preserveTrailingDash: true}), 'foo-bar-');
+	t.is(slugify('foo-bar -', {preserveTrailingDash: true}), 'foo-bar-');
+	t.is(slugify('foo-bar - ', {preserveTrailingDash: true}), 'foo-bar');
+	t.is(slugify('foo-bar ', {preserveTrailingDash: true}), 'foo-bar');
 });
 
 test('counter', t => {


### PR DESCRIPTION
I'm using `slugify` on an input for the user to create a `slug` like below:

```
const [slug, setSlug] = useState();

<input onChange={(value) => setSlug(slugify(value))} value={slug} />
```

and so I want the user input to be slugified on the spot, but the problem is that the user cannot enter a dash in the input, since it will get removed. 

With this PR, I should be able to do `slugify(value, {preserveTrailingDash: true})` and make my use case work. 

It seems like a pretty generic use case so I thought I'd make a PR (looked at https://github.com/sindresorhus/slugify/pull/43 for a code style reference).

P. S. I will need to call `slugify` once more without `preserveTrailingDash` before submitting the form to make sure I don't have a trailing dash in the final slug, but that's ok.