### PR TITLE
Add `preserveCharacters` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -132,6 +132,31 @@ export interface Options {
 	```
 	 */
 	readonly preserveTrailingDash?: boolean;
+
+	/**
+	Add an array of characters that should be considered as a valid part of a slug and therefore preserved.
+
+	All custom replacement transformations are happening before that. So replaced characters wouldn't be preserved.
+
+	Use this option with caution because it may lead to an invalid url string.
+
+	Using this option with `preserveLeadingUnderscore` or `preserveTrailingDash` options may lead to unexpected results.
+	Because leading underscore and trailing dash transformations happening afterwards.
+
+	@default []
+
+	@example
+	```
+	import slugify from '@sindresorhus/slugify';
+
+	slugify('foo_bar_');
+	//=> 'foo-bar'
+
+	slugify('foo_bar_', {preserveCharacters: ['_']});
+	//=> 'foo_bar_'
+	```
+	 */
+	readonly preserveCharacters?: readonly string[];
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ export default function slugify(string, options) {
 		customReplacements: [],
 		preserveLeadingUnderscore: false,
 		preserveTrailingDash: false,
+		preserveCharacters: [],
 		...options
 	};
 
@@ -49,14 +50,22 @@ export default function slugify(string, options) {
 		string = decamelize(string);
 	}
 
-	let patternSlug = /[^a-zA-Z\d]+/g;
+	let patternCharacters = ['a-z', 'A-Z', '\\d'];
 
 	if (options.lowercase) {
 		string = string.toLowerCase();
-		patternSlug = /[^a-z\d]+/g;
+		patternCharacters = patternCharacters.filter(char => char !== 'A-Z');
 	}
 
+	if (options.preserveCharacters.length > 0) {
+		const preserveCharacters = options.preserveCharacters.map(char => escapeStringRegexp(char));
+		patternCharacters = [...patternCharacters, ...preserveCharacters];
+	}
+
+	const patternSlug = new RegExp(`[^${patternCharacters.join('')}]`,'g')
+
 	string = string.replace(patternSlug, options.separator);
+
 	string = string.replace(/\\/g, '');
 	if (options.separator) {
 		string = removeMootSeparators(string, options.separator);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -8,6 +8,7 @@ expectType<string>(slugify('fooBar', {decamelize: false}));
 expectType<string>(slugify('I ♥ 🦄 & 🐶', {customReplacements: [['🐶', 'dog']]}));
 expectType<string>(slugify('_foo_bar', {preserveLeadingUnderscore: true}));
 expectType<string>(slugify('foo-bar-', {preserveTrailingDash: true}));
+expectType<string>(slugify('foo_bar baz', {preserveCharacters: ['_']}));
 
 // Counter
 expectType<string>(slugifyWithCounter()('I ♥ Dogs'));

--- a/test.js
+++ b/test.js
@@ -141,6 +141,14 @@ test('trailing dash', t => {
 	t.is(slugify('foo-bar ', {preserveTrailingDash: true}), 'foo-bar');
 });
 
+test('preserved characters', t => {
+	t.is(slugify('foo_bar', {preserveCharacters: ['_']}), 'foo_bar');
+	t.is(slugify('foo__bar', {preserveCharacters: ['_']}), 'foo__bar');
+	t.is(slugify('_foo_bar_', {preserveCharacters: ['_']}), '_foo_bar_');
+	t.is(slugify('_ foo _ bar _', {preserveCharacters: ['_']}), '_-foo-_-bar-_');
+	t.is(slugify('foo_bar baz', {preserveCharacters: ['_']}), 'foo_bar-baz');
+});
+
 test('counter', t => {
 	const slugify = slugifyWithCounter();
 	t.is(slugify('foo bar'), 'foo-bar');


### PR DESCRIPTION
Hi,

This PR implements logic of preserving characters in slug.
I added tests and documentation as well.

This is the first draft, because I have some doubts about current implementation and possible caveats. One of the issues is work with other options. 

---

Consider given example (I have no idea who would decide to do that but still): 
```
slugify('_foo bar', { preserveLeadingUnderscore: true, preserveCharacters: ['_'] })
=> __foo-bar
```
It's probably wrong behaviour. So we need either provide a warning, or add a check
```
if (shouldPrependUnderscore && !string.startsWith('_')) {
  string = `_${string}`;
}
```
But it feels so wrong. So I'm not sure that it's right way.

---

And another issue is how to ensure that people using this option correctly. An array of single characters. Not words / sequences of characters. Because it would work differently than expected. Or maybe we should provide possibility to preserve words or sequences of characters. But in this case implementation definitely should be changed.