### PR TITLE
Do not decamelize plural acronyms.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ const decamelize = string => {
 		.replace(/([a-z\d]+)([A-Z]{2,})/g, '$1 $2')
 
 		.replace(/([a-z\d])([A-Z])/g, '$1 $2')
-		// [a-rt-z] matches all lowercase characters except 's'.
-		// This avoids matching plural acronyms like 'APIs'.
+		// `[a-rt-z]` matches all lowercase characters except `s`.
+		// This avoids matching plural acronyms like `APIs`.
 		.replace(/([A-Z]+)([A-Z][a-rt-z\d]+)/g, '$1 $2');
 };
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const decamelize = string => {
 		.replace(/([a-z\d]+)([A-Z]{2,})/g, '$1 $2')
 
 		.replace(/([a-z\d])([A-Z])/g, '$1 $2')
-		.replace(/([A-Z]+)([A-Z][a-z\d]+)/g, '$1 $2');
+		.replace(/([A-Z]+)([A-Z][a-rt-z\d]+)/g, '$1 $2');
 };
 
 const removeMootSeparators = (string, separator) => {

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const decamelize = string => {
 		.replace(/([a-z\d]+)([A-Z]{2,})/g, '$1 $2')
 
 		.replace(/([a-z\d])([A-Z])/g, '$1 $2')
+		// [a-rt-z] matches all lowercase characters except 's'.
+		// This avoids matching plural acronyms like 'APIs'.
 		.replace(/([A-Z]+)([A-Z][a-rt-z\d]+)/g, '$1 $2');
 };
 

--- a/test.js
+++ b/test.js
@@ -24,6 +24,8 @@ test('main', t => {
 	t.is(slugify('foo360BAR'), 'foo360-bar');
 	t.is(slugify('FOO360'), 'foo-360');
 	t.is(slugify('FOOBar'), 'foo-bar');
+	t.is(slugify('APIs'), 'apis');
+	t.is(slugify('Util APIs'), 'util-apis');
 });
 
 test('custom separator', t => {

--- a/test.js
+++ b/test.js
@@ -25,6 +25,7 @@ test('main', t => {
 	t.is(slugify('FOO360'), 'foo-360');
 	t.is(slugify('FOOBar'), 'foo-bar');
 	t.is(slugify('APIs'), 'apis');
+	t.is(slugify('APISection'), 'api-section');
 	t.is(slugify('Util APIs'), 'util-apis');
 });
 


### PR DESCRIPTION
Fixes #60 by removing the letter `s` from the offending decamelization regex.

Does it feel hacky? Maybe 😆 ! But, it passes the test suite, so it can at least get the conversation started.