### PR TITLE
Initial work on character preservation option.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -132,6 +132,25 @@ export interface Options {
 	```
 	 */
 	readonly preserveTrailingDash?: boolean;
+
+	/**
+	Preserve certain characters.
+
+	It cannot contain the `separator`.
+
+	For example, if you want to slugify URLs, but preserve the HTML fragment `#` character, you could set `preserveCharacters: ['#']`.
+
+	@default []
+
+	@example
+	```js
+	import slugify from '@sindresorhus/slugify';
+
+	slugify('foo_bar#baz', {preserveCharacters: ['#']});
+	//=> 'foo-bar#baz'
+	```
+	 */
+	readonly preserveCharacters?: string[];
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -143,13 +143,13 @@ export interface Options {
 	@default []
 
 	@example
-	```js
+	```
 	import slugify from '@sindresorhus/slugify';
 
 	slugify('foo_bar#baz', {preserveCharacters: ['#']});
 	//=> 'foo-bar#baz'
 	```
-	 */
+	*/
 	readonly preserveCharacters?: string[];
 }
 

--- a/index.js
+++ b/index.js
@@ -27,18 +27,16 @@ const buildPatternSlug = options => {
 	negationSetPattern += options.lowercase ? '' : 'A-Z';
 
 	if (options.preserveCharacters.length > 0) {
-		for (const char of options.preserveCharacters) {
-			if (char === options.separator) {
-				throw new Error(`Separator, ${options.separator}, cannot be included in preserved characters, ${options.preserveCharacters}`);
-			} else {
-				negationSetPattern += escapeStringRegexp(char);
+		for (const character of options.preserveCharacters) {
+			if (character === options.separator) {
+				throw new Error(`The separator character \`${options.separator}\` cannot be included in preserved characters: ${options.preserveCharacters}`);
 			}
+
+			negationSetPattern += escapeStringRegexp(character);
 		}
 	}
 
-	const negationSet = `[^${negationSetPattern}]+`;
-
-	return new RegExp(negationSet, 'g');
+	return new RegExp(`[^${negationSetPattern}]+`, 'g');
 };
 
 export default function slugify(string, options) {

--- a/index.js
+++ b/index.js
@@ -23,19 +23,15 @@ const removeMootSeparators = (string, separator) => {
 };
 
 const buildPatternSlug = options => {
-	// The allowSet contains some url-safe non-alphanumeric characters
-	const allowSet = new Set(['.', '#', '-', '_']);
 	let negationSetPattern = 'a-z\\d';
-	if (!options.lowercase) {
-		negationSetPattern += 'A-Z';
-	}
+	negationSetPattern += options.lowercase ? '' : 'A-Z';
 
 	if (options.preserveCharacters.length > 0) {
-		for (const c of options.preserveCharacters) {
-			if (c === options.separator) {
+		for (const char of options.preserveCharacters) {
+			if (char === options.separator) {
 				throw new Error(`Separator, ${options.separator}, cannot be included in preserved characters, ${options.preserveCharacters}`);
-			} else if (allowSet.has(c)) {
-				negationSetPattern += escapeStringRegexp(c);
+			} else {
+				negationSetPattern += escapeStringRegexp(char);
 			}
 		}
 	}

--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,7 @@ Preserve certain characters.
 
 It cannot contain the `separator`.
 
-For example, if you want to slugify URLs, but preserve the HTML fragment `#` and `.` characters.
+For example, if you want to slugify URLs, but preserve the HTML fragment `#` character.
 
 ```js
 import slugify from '@sindresorhus/slugify';

--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,9 @@ slugify('foo-bar-', {preserveTrailingDash: true});
 Type: `string[]`\
 Default: `[]`
 
-Preserve particular characters so long as they are **not** the separator.
+Preserve certain characters.
+
+It cannot contain the `separator`.
 
 For example, if you wanted to slugify urls, but preserve the HTML fragment `#`, and `.` characters.
 

--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,7 @@ Preserve certain characters.
 
 It cannot contain the `separator`.
 
-For example, if you wanted to slugify urls, but preserve the HTML fragment `#`, and `.` characters.
+For example, if you want to slugify URLs, but preserve the HTML fragment `#` and `.` characters.
 
 ```js
 import slugify from '@sindresorhus/slugify';

--- a/readme.md
+++ b/readme.md
@@ -188,8 +188,8 @@ slugify('foo-bar-', {preserveTrailingDash: true});
 
 ##### preserveCharacters
 
-Type: `Array<string>`\
-default: `[]`
+Type: `string[]`\
+Default: `[]`
 
 Preserve particular characters so long as they are **not** the separator.
 

--- a/readme.md
+++ b/readme.md
@@ -186,6 +186,22 @@ slugify('foo-bar-', {preserveTrailingDash: true});
 //=> 'foo-bar-'
 ```
 
+##### preserveCharacters
+
+Type: `Array<string>`\
+default: `[]`
+
+Preserve particular characters so long as they are **not** the separator.
+
+For example, if you wanted to slugify urls, but preserve the HTML fragment `#`, and `.` characters.
+
+```js
+import slugify from '@sindresorhus/slugify';
+
+slugify('foo_bar#baz', {preserveCharacters: ['#']});
+//=> 'foo-bar#baz'
+```
+
 ### slugifyWithCounter()
 
 Returns a new instance of `slugify(string, options?)` with a counter to handle multiple occurrences of the same string.

--- a/test.js
+++ b/test.js
@@ -194,6 +194,4 @@ test('preserve characters', t => {
 	t.throws(() => {
 		slugify('foo', {separator: '.', preserveCharacters: ['.']});
 	});
-	// Not implicit-whitelist-approved
-	t.is(slugify('foo$bar', {preserveCharacters: ['$']}), 'foo-bar');
 });

--- a/test.js
+++ b/test.js
@@ -179,3 +179,21 @@ test('counter', t => {
 	t.is(slugify2(''), '');
 	t.is(slugify2(''), '');
 });
+
+test('preserve characters', t => {
+	t.is(slugify('foo#bar', {preserveCharacters: []}), 'foo-bar');
+	t.is(slugify('foo.bar', {preserveCharacters: []}), 'foo-bar');
+	t.is(slugify('foo?bar ', {preserveCharacters: ['#']}), 'foo-bar');
+	t.is(slugify('foo#bar', {preserveCharacters: ['#']}), 'foo#bar');
+	t.is(slugify('foo_bar#baz', {preserveCharacters: ['#']}), 'foo-bar#baz');
+	t.is(slugify('foo.bar#baz-quux', {preserveCharacters: ['.', '#']}), 'foo.bar#baz-quux');
+	t.is(slugify('foo.bar#baz-quux', {separator: '.', preserveCharacters: ['-']}), 'foo.bar.baz-quux');
+	t.throws(() => {
+		slugify('foo', {separator: '-', preserveCharacters: ['-']});
+	});
+	t.throws(() => {
+		slugify('foo', {separator: '.', preserveCharacters: ['.']});
+	});
+	// Not implicit-whitelist-approved
+	t.is(slugify('foo$bar', {preserveCharacters: ['$']}), 'foo-bar');
+});


### PR DESCRIPTION
Fixes #55 

I wanted to preserve the HTML fragment, `#`, in my use-case for slugify. I saw #55 and thought I'd kick off the PR for it.

