### PR TITLE
Perform contraction/possession replacement before main pattern replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,12 +75,12 @@ export default function slugify(string, options) {
 		string = string.toLowerCase();
 	}
 
+	// Detect contractions/possessives by looking for any word followed by a `'t`
+	// or `'s` in isolation and then remove it.
+	string = string.replace(/([a-zA-Z\d]+)'([ts])(\s|$)/g, '$1$2$3');
+
 	string = string.replace(patternSlug, options.separator);
 	string = string.replace(/\\/g, '');
-
-	// Detect contractions/possessives by looking for any word followed by a `-t`
-	// or `-s` in isolation and then remove it.
-	string = string.replace(/([a-zA-Z\d]+)-([ts])(-|$)/g, '$1$2$3');
 
 	if (options.separator) {
 		string = removeMootSeparators(string, options.separator);

--- a/test.js
+++ b/test.js
@@ -34,6 +34,7 @@ test('possessives and contractions', t => {
 	t.is(slugify('Conway\'s'), 'conways');
 	t.is(slugify('Don\'t Repeat Yourself'), 'dont-repeat-yourself');
 	t.is(slugify('my parents\' rules'), 'my-parents-rules');
+	t.is(slugify('it-s-hould-not-modify-t-his'), 'it-s-hould-not-modify-t-his');
 });
 
 test('custom separator', t => {


### PR DESCRIPTION
This aims to fix #72 by performing the replacement on the input string instead of the already slugified string. 